### PR TITLE
New mirror server Mauritius

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Server = https://mirror.jordanrey.me/endeavouros/repo/$repo/$arch
 ## India
 Server = https://mirror.albony.xyz/endeavouros/repo/$repo/$arch
 
+## Mauritius
+Server = https://endeavouros-mirror.cloud.mu/endeavouros/repo/$repo/$arch
+
 ## Moldova
 Server = https://md.mirrors.hacktegic.com/endeavouros/repo/$repo/$arch
 


### PR DESCRIPTION
Mirror domain name: endeavouros-mirror.cloud.mu

Geographical location of the mirror (country): Mauritius (MU)

URLs for supported access methods : http, https

Mirror's available bandwidth: 100 Mbit/s

An administrative contact email : [mirror-admin@lists.mixp.org](mailto:mirror-admin@lists.mixp.org)